### PR TITLE
Fixed compilation on OSX >= Mavericks, but still need special CXXFLAGS, see pull request comment

### DIFF
--- a/app/interrupt_handler_override.cpp
+++ b/app/interrupt_handler_override.cpp
@@ -41,6 +41,9 @@ namespace
   {
   }
 #else
+#if defined (__APPLE__)
+  typedef void (*sighandler_t)(int);
+#endif
   sighandler_t old_handler;
 
   void sigint_handler(int)

--- a/lib/text_position.cpp
+++ b/lib/text_position.cpp
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <metashell/text_position.hpp>
+#include <iostream>
 
 #include <boost/foreach.hpp>
 


### PR DESCRIPTION
Hi, if you're interested I made a couple of small tweaks to build on OSX 10.9 with Xcode5's clang and libc++.
There's a slight problem in the code, specifically at lib/cxtranslationunit.cpp#119 where the address of std::string::c_str is taken, that causes linking to fail though.
As pointed out in http://clang-developers.42468.n3.nabble.com/LIBCPP-INLINE-VISIBILITY-and-std-string-length-td4030879.html, "[...] this code is not required to work, because you are not generally allowed to take the address of functions from the standard library".
In any case, adding -D'_LIBCPP_EXTERN_TEMPLATE(...)=' (as suggested in the linked page) to the CXXFLAGS, solves the link problem.
I didn't find an easy way for CMakeLists.txt to detect if it was using libc++ and hence activate the fix, I could just apply it if "__APPLE__" was defined, but that's not really the right way to do it, so I leave to you deciding, if you want, how to apply that.

Andrea.
