### PR TITLE
Fix SIGSEGV in pragma parsing with trailing whitespace

### DIFF
--- a/lib/pragma_handler_map.cpp
+++ b/lib/pragma_handler_map.cpp
@@ -66,7 +66,13 @@ namespace
       && *i == string(begin_->get_value().begin(), begin_->get_value().end()))
     {
       ++i;
-      begin_ = skip_whitespace(skip(begin_));
+      begin_ = skip(begin_);
+      // Don't accidentally skip over end_
+      if (begin_ == end_)
+      {
+        break;
+      }
+      begin_ = skip_whitespace(begin_);
     }
     return
       i == e ? optional<token_iterator>(begin_) : optional<token_iterator>();


### PR DESCRIPTION
The pragma parsing algorithm caused Segmentation fault,
when the pragma handler tried to read the passed
token_iterators when only whitespace token(s) should've
appeared in the range. The reason is, that the algorithm
skipped over the whitespace token onto the EOI, EOF tokens.

Example test input:
"#msh environment add "
