### PR TITLE
Make minimum depth of included headers configurable in gen_toc

### DIFF
--- a/tools/gen_toc
+++ b/tools/gen_toc
@@ -54,13 +54,13 @@ def collect_headers(doc, toc_type):
     anchors.append(h.anchor)
   return headers
 
-def generate_toc(headers, toc_title):
+def generate_toc(headers, toc_title, min_depth):
   return \
     '\n'.join( \
-      [h.toc_line(-1) for h in headers if h.depth > 0 and h.title != toc_title]\
+      [h.toc_line(-min_depth) for h in headers if h.depth >= min_depth and h.title != toc_title]\
     ) + '\n'
 
-def generate_doc(f, doc, toc_title, toc_type):
+def generate_doc(f, doc, toc_title, toc_type, min_depth):
   in_toc = False
   for s in doc:
     if in_toc:
@@ -72,7 +72,7 @@ def generate_doc(f, doc, toc_title, toc_type):
         in_toc = True
         if toc_type != 'none':
           f.write(s + '\n')
-          f.write(generate_toc(collect_headers(doc, toc_type), toc_title))
+          f.write(generate_toc(collect_headers(doc, toc_type), toc_title, min_depth))
           f.write('\n')
       else:
         f.write(s)
@@ -100,7 +100,15 @@ def main():
     help='Type of TOC. Possible values: %s. Default: %s'
       % (', '.join(accepted_types), 'github')
   )
-  
+  parser.add_option(
+    '-d', '--min-depth',
+    action='store',
+    dest='min_depth',
+    type='int',
+    default='1',
+    help='The minimum depth of the title to put in the TOC. Depth 0 is the first level (h1).'
+  )
+
   (options, args) = parser.parse_args()
   if options.output == None:
     options.output = options.input
@@ -116,7 +124,7 @@ def main():
       f = sys.stdout
     else:
       f = open(options.output, 'w')
-    generate_doc(f, doc, toc_title, options.type)
+    generate_doc(f, doc, toc_title, options.type, options.min_depth)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
I tried to use gen_toc for my own project, and found that it skips the first level of headers. I modified it to be configurable by a command line argument. The default behavior is the same as before, so your TOC is not broken if you use it the same way as before, but the script can be more useful for more general purposes.
