### PR TITLE
Fix executable path detection on OS X

### DIFF
--- a/include/metashell/default_environment_detector.hpp
+++ b/include/metashell/default_environment_detector.hpp
@@ -35,6 +35,8 @@ namespace metashell
     virtual boost::filesystem::path directory_of_executable() override;
 
   private:
+    boost::filesystem::path path_of_executable();
+
     std::string _argv0;
   };
 }


### PR DESCRIPTION
The problem manifested itself, when metashell was running
under valgrind. `getpit` returned the pid of the valgrind
process, which caused proc_pidpath to return the path for
the valgrind process.

Also tried `_NSGetExecutablePath`. This has some race condition
problems inside apple code while running under valgrind.

So the solution is to fallback to the cross platform detection code.

Fixes metashell/metashell#118

Also fixes OpenBsd compilation which was broken since
`path_of_executable` is not a member of `default_environment_detector`.