### PR TITLE
Make the path to the llvm directory the last argument of cmake in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,10 +62,11 @@ then
   cd 3rd
     cd templight
       mkdir -p build; cd build
-        cmake ../llvm \
+        cmake \
           -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
           -DLLVM_ENABLE_TERMINFO=OFF \
           "${C_INCLUDE_DIRS}" \
+          ../llvm \
           && make templight -j${BUILD_THREADS}
       cd ..
     cd ..


### PR DESCRIPTION
Newer versions of CMake don't seem to work when it is the first argument.