### PR TITLE
Resolve symlinks in path_of_executable

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -15,6 +15,11 @@
       the Templight (shipped with Metashell) on the system include path and the
       macros of Templight defined by default.
 
+* Fixes
+    * The `templight_metashell` executable is found even if the `metashell`
+      executable is behind a symlink on macOS and OpenBSD systems. This also
+      broke the Homebrew version of metashell.
+
 ## Version 3.0.0
 
 * New features

--- a/lib/core/default_environment_detector.cpp
+++ b/lib/core/default_environment_detector.cpp
@@ -102,10 +102,14 @@ namespace
   boost::filesystem::path path_of_executable(const std::string& argv0_)
   {
 #ifdef _WIN32
+    (void)argv0_;
+
     char path[MAX_PATH];
     GetModuleFileName(GetModuleHandle(NULL), path, sizeof(path));
     return path;
 #elif defined __FreeBSD__
+    (void)argv0_;
+
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
     std::vector<char> buff(1);
     size_t cb = buff.size();
@@ -142,6 +146,7 @@ namespace
       return "";
     }
 #else
+    (void)argv0_;
     return read_link("/proc/self/exe");
 #endif
   }

--- a/lib/core/default_environment_detector.cpp
+++ b/lib/core/default_environment_detector.cpp
@@ -150,7 +150,7 @@ namespace
 boost::filesystem::path default_environment_detector::path_of_executable()
 {
   // resolve symlinks with boost::filesystem::canonical
-  return canonical(path_of_executable(_argv0));
+  return canonical(::path_of_executable(_argv0));
 }
 
 default_environment_detector::default_environment_detector(

--- a/tools/demo_server/bin/deploy
+++ b/tools/demo_server/bin/deploy
@@ -43,8 +43,8 @@ def deploy_event(step_name, action, name):
     act = '{0} {1}'.format(step_name, action)
     if name is None:
         return '{0} {1} {0}'.format(prefix, act)
-    else:
-        return '{0} {1}: {2} {0}'.format(prefix, name, act)
+
+    return '{0} {1}: {2} {0}'.format(prefix, name, act)
 
 
 def set_permissions(path):
@@ -157,7 +157,7 @@ def root_of_a_git_repository(path):
 def choose_initial_dir(out_dir):
     """Choose an initial directory for cloning the repository into"""
     dirs = os.listdir(out_dir)
-    while len(dirs) > 0:
+    while dirs:
         current = dirs[0]
 
         if root_of_a_git_repository(current):
@@ -392,11 +392,11 @@ class Branch(object):
         """Collect deployment information"""
         if self.was_build_error:
             return []
-        else:
-            deployer = Deployer(config_name, self, out_dir, self.log)
-            return flatten(
-                deployer.deployment_info(f, t) for (t, f) in deploy_info
-            )
+
+        deployer = Deployer(config_name, self, out_dir, self.log)
+        return flatten(
+            deployer.deployment_info(f, t) for (t, f) in deploy_info
+        )
 
     def generate_launcher(self, out_dir, launcher, config_name, search_list):
         """Generate the launcher page"""
@@ -492,8 +492,7 @@ def determine_to_path_suffix(entry_config, from_path_suffix):
     if 'dst' in entry_config:
         return \
             None if entry_config['dst'] in ['', '.'] else entry_config['dst']
-    else:
-        return from_path_suffix
+    return from_path_suffix
 
 
 class Deployer(object):
@@ -563,22 +562,22 @@ class Deployer(object):
         """Collects the files to deploy"""
         if to_path in ['include', 'share']:
             return self._complex_deploy_info(entry_config, to_path)
-        else:
-            abs_to_path = os.path.join(
-                self.relative(to_path),
-                os.path.basename(entry_config)
-            )
-            return [
-                FileDeployment(
-                    self.name,
-                    abs_to_path + '_' + self.branch.last_commit,
-                    (
-                        self.in_src_dir(entry_config),
-                        abs_to_path + '_' + self.branch.last_commit
-                    ),
-                    abs_to_path + '_' + escape_branch_name(self.branch.name)
-                ).with_base(self.name).with_to_path(to_path)
-            ]
+
+        abs_to_path = os.path.join(
+            self.relative(to_path),
+            os.path.basename(entry_config)
+        )
+        return [
+            FileDeployment(
+                self.name,
+                abs_to_path + '_' + self.branch.last_commit,
+                (
+                    self.in_src_dir(entry_config),
+                    abs_to_path + '_' + self.branch.last_commit
+                ),
+                abs_to_path + '_' + escape_branch_name(self.branch.name)
+            ).with_base(self.name).with_to_path(to_path)
+        ]
 
 
 def collect_symlinks(out_dir):
@@ -655,8 +654,7 @@ class DeployedLib(object):
         """Returns the display name of the library"""
         if self.name() == '':
             return ''
-        else:
-            return self.name()[0].upper() + self.name()[1:]
+        return self.name()[0].upper() + self.name()[1:]
 
     def launcher_info(self):
         """Builds the tuple describing the launcher information"""

--- a/tools/demo_server/test/test_generate_launcher
+++ b/tools/demo_server/test/test_generate_launcher
@@ -43,8 +43,7 @@ def get_config(name, configs):
     cfgs = [c for c in configs if c['name'] == name]
     if len(cfgs) == 1:
         return cfgs[0]
-    else:
-        return None
+    return None
 
 
 # pylint: disable=missing-docstring

--- a/tools/validate/mkdocs
+++ b/tools/validate/mkdocs
@@ -43,7 +43,7 @@ def run(mkdocs_yml):
         load_yml(mkdocs_yml),
         os.path.dirname(os.path.abspath(mkdocs_yml)) + '/docs'
     )
-    if len(errors) > 0:
+    if errors:
         for err in errors:
             print err
         sys.exit(1)

--- a/tools/validate/pylint.sh
+++ b/tools/validate/pylint.sh
@@ -27,10 +27,12 @@ fi
 # PYTHONPATH
 for f in $(tools/list/python_files.sh tools)
 do
+  echo "pylint on '${f}'"
   pylint \
     --disable=bare-except \
     --disable=locally-disabled \
     --disable=locally-enabled \
     --disable=similarities \
+    --disable=useless-super-delegation \
     "${f}"
 done


### PR DESCRIPTION
Fixes https://github.com/metashell/metashell/issues/163

The diff seems complicated, but I only extracted path_of_executable to an anonymous namespace function, and wrapped it inside `boost::filesystem::canonical`, which resolves the symlinks and returns the unique absolute path.