### PR TITLE
Travis OS X fix

### DIFF
--- a/lib/core/console_displayer.cpp
+++ b/lib/core/console_displayer.cpp
@@ -298,7 +298,7 @@ console_displayer::format_metaprogram_node(const data::metaprogram_node& n_)
           result,
           [this](const data::cpp_code& s_) { return this->format_code(s_); },
           [this](const data::token& t_) { return this->format_token(t_); },
-          [this](const boost::filesystem::path& p_) {
+          [](const boost::filesystem::path& p_) {
             return data::colored_string(p_.string());
           }),
       n_);

--- a/tools/travis/osx.sh
+++ b/tools/travis/osx.sh
@@ -3,6 +3,11 @@
 set -ex
 
 brew update >/dev/null
+
+# Oclint installs something under /usr/local/include/c++ which
+# conflicts with files installed by gcc
+brew cask uninstall oclint
+
 brew install p7zip
 
 if [ "$CXX" = "g++" ]; then

--- a/tools/travis/osx.sh
+++ b/tools/travis/osx.sh
@@ -11,8 +11,8 @@ brew cask uninstall oclint
 brew install p7zip
 
 if [ "$CXX" = "g++" ]; then
-  brew install homebrew/versions/gcc5
-  export CXX="g++-5"
+  brew install gcc@6
+  export CXX="g++-6"
 fi
 
 # Test that the download version links are correct

--- a/tools/validate/format.sh
+++ b/tools/validate/format.sh
@@ -27,7 +27,7 @@ CLANG_FORMAT="$(tools/find/clang_format.sh)"
 
 for f in $(tools/list/cpp_files.sh)
 do
-  ("${CLANG_FORMAT}" "${f}" | diff "${f}" -) || ( \
+  ("${CLANG_FORMAT}" "${f}" | diff --context "${f}" -) || ( \
     echo "Invalid code formatting in ${f}. Please run tools/reformat.sh to fix it." \
     ; exit 1 \
   )

--- a/tools/validate/format.sh
+++ b/tools/validate/format.sh
@@ -25,6 +25,8 @@ fi
 
 CLANG_FORMAT="$(tools/find/clang_format.sh)"
 
+"${CLANG_FORMAT}" -version
+
 for f in $(tools/list/cpp_files.sh)
 do
   ("${CLANG_FORMAT}" "${f}" | diff --context "${f}" -) || ( \


### PR DESCRIPTION
Oclint was installed by default on the OS X nodes, which conflicted with brew's gcc. So uninstall oclint first. Also upgraded to gcc@6, because gcc@5 emitted code that caused triggered harmless warnings from the rest of the OS X toolchain. The amount of warnings caused travis to abort the jobs due to too long build output. For example: https://travis-ci.org/r0mai/metashell/jobs/325858269

I have some clang-format related commits, because for some strange reason, some of my runs were running clang-format 5.0.0 and some others clang-format 3.8.0.

Same commit, one red, one green:
https://travis-ci.org/r0mai/metashell/jobs/325928926#L827
https://travis-ci.org/metashell/metashell/jobs/326024551#L827