### PR TITLE
Fixes for OS X tests

### DIFF
--- a/lib/core/engine_gcc.cpp
+++ b/lib/core/engine_gcc.cpp
@@ -78,7 +78,7 @@ namespace
   gcc_args(const std::vector<std::string>& extra_gcc_args_,
            const boost::filesystem::path& internal_dir_)
   {
-    std::vector<std::string> args{"-iquote", ".", "-x", "c++-header"};
+    std::vector<std::string> args{"-iquote", ".", "-x", "c++"};
 
     if (stdinc_allowed(extra_gcc_args_))
     {

--- a/lib/core/parse_wave_config.cpp
+++ b/lib/core/parse_wave_config.cpp
@@ -103,8 +103,14 @@ namespace
   clang_macros(const metashell::clang_binary& cbin_,
                const boost::filesystem::path& internal_dir_)
   {
+    // Need to have __has_feature(cxx_decltype) to return true in order
+    // to be able to parse libcxx headers. They define decltype as a macro
+    // otherwise, and call it with template expression that contains
+    // multiple preprocessor parameters.
     std::vector<std::string> result{
-        "__has_include_next(_)=0", "__has_feature(_)=0"};
+        "__has_include_next(_)=0",
+        "__metashell_has_feature_impl__cxx_decltype=1",
+        "__has_feature(x)=__metashell_has_feature_impl__ ## x"};
 
     metashell::empty_environment env(internal_dir_);
     const metashell::data::cpp_code defines =

--- a/lib/core/wave_context.cpp
+++ b/lib/core/wave_context.cpp
@@ -21,17 +21,37 @@
 
 namespace
 {
+  boost::optional<boost::filesystem::path>
+  canonical_path(const boost::filesystem::path& path)
+  {
+    boost::system::error_code ec;
+    auto res = boost::filesystem::canonical(path, ec);
+    if (ec.value() == boost::system::errc::success)
+    {
+      return res;
+    }
+    return boost::none;
+  }
+
   void apply(metashell::wave_context& ctx_,
              const metashell::data::includes& includes_)
   {
     for (const boost::filesystem::path& p : includes_.sys)
     {
-      ctx_.add_sysinclude_path(p.string().c_str());
+      auto cp = canonical_path(p);
+      if (cp)
+      {
+        ctx_.add_sysinclude_path(cp->string().c_str());
+      }
     }
     for (const boost::filesystem::path& p : includes_.quote)
     {
-      ctx_.add_include_path(p.string().c_str());
-      ctx_.add_sysinclude_path(p.string().c_str());
+      auto cp = canonical_path(p);
+      if (cp)
+      {
+        ctx_.add_include_path(cp->string().c_str());
+        ctx_.add_sysinclude_path(cp->string().c_str());
+      }
     }
   }
 

--- a/test/system/app/pdb/test_include.cpp
+++ b/test/system/app/pdb/test_include.cpp
@@ -22,7 +22,7 @@
 
 #include <just/temp.hpp>
 
-#include <boost/filesystem/path.hpp>
+#include <boost/filesystem.hpp>
 
 #include <fstream>
 
@@ -55,7 +55,7 @@ namespace
   std::string test_hpp_path(const boost::filesystem::path& tmp_dir_path_)
   {
     return workaround_for_wave_on_windows(
-        (tmp_dir_path_ / "test.hpp").string());
+        (boost::filesystem::canonical(tmp_dir_path_) / "test.hpp").string());
   }
 
   template <event_kind Kind>

--- a/test/system/app/pp/test_included_headers.cpp
+++ b/test/system/app/pp/test_included_headers.cpp
@@ -79,7 +79,8 @@ namespace
     {
       return filename_set(filenames_ | boost::adaptors::transformed([this](
                                            const boost::filesystem::path& p_) {
-                            return this->relative(p_);
+                            return boost::filesystem::canonical(
+                                this->relative(p_));
                           }));
     }
 

--- a/test/system/lib/filename_set.cpp
+++ b/test/system/lib/filename_set.cpp
@@ -21,6 +21,8 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <boost/filesystem.hpp>
+
 #include <iostream>
 
 using namespace metashell::system_test;
@@ -40,7 +42,7 @@ filename_set::filename_set(const json_string& s_)
     {
       if (i->IsString())
       {
-        _paths.insert(i->GetString());
+        _paths.insert(boost::filesystem::canonical(i->GetString()));
       }
       else
       {


### PR DESCRIPTION
These failures were hidden so far, because the job didn't fail on test failures.

There is one more wave failure that happens on this branch, but that will be fixed by https://github.com/metashell/metashell/pull/181 (It's a libcxx related issue)