### PR TITLE
Apple specific path_of_executable() implementation

### DIFF
--- a/lib/core/default_environment_detector.cpp
+++ b/lib/core/default_environment_detector.cpp
@@ -135,7 +135,7 @@ namespace
     {
       const std::string p = just::environment::get("PATH");
       std::vector<boost::filesystem::path> path;
-      boost::split(path, p, [](char c_) { return c_ == ';'; });
+      boost::split(path, p, [](char c_) { return c_ == ':'; });
       for (const auto& s : path)
       {
         const boost::filesystem::path fn = s / argv0_;


### PR DESCRIPTION
Original root cause was that on OS X (and I believe on all Posix platforms) the $PATH separator character is `':'` not `';'`, which caused `path_of_executable()` to do all kinds of wrong things.

While I was there I added a more robust, OS X specific implementation. I feel this $PATH based implementation can still be fooled if you have multiple `metashell`s on your path.

Related PR: https://github.com/metashell/metashell/pull/129

`_NSGetExecutablePath` has (or had) problems when used under valgrind. Unfortunately valgrind doesn't work on the newest OS X versions, so I can't test this.

We need to verify if the path separator is indeed `':'` on OpenBSD as well before the release.