### PR TITLE
Detect Apple Clang too in is_clang

### DIFF
--- a/lib/engine/clang/src/this_engine.cpp
+++ b/lib/engine/clang/src/this_engine.cpp
@@ -31,8 +31,9 @@ namespace metashell
       {
         try
         {
-          return regex_search(process::run(clang_, {"-v"}, "").standard_error,
-                              std::regex("^clang version "));
+          return regex_search(
+              process::run(clang_, {"-v"}, "").standard_error,
+              std::regex("^(clang version |Apple LLVM version )"));
         }
         catch (const process::exception&)
         {


### PR DESCRIPTION
This enables using the compile-commands feature with projects compiled by the default compiler shipped with XCode.