### PR TITLE
Recognize newer Apple clang versions

### DIFF
--- a/lib/engine/clang/src/this_engine.cpp
+++ b/lib/engine/clang/src/this_engine.cpp
@@ -34,7 +34,8 @@ namespace metashell
           return regex_search(
               process::run(data::command_line(clang_, {"-v"}), "")
                   .standard_error,
-              std::regex("^(clang version |Apple LLVM version )"));
+              std::regex("^(clang version |Apple LLVM version |Apple clang "
+                         "version )"));
         }
         catch (const process::exception&)
         {


### PR DESCRIPTION
At some point Apple changed the clang binary's --version output. Now it looks like this:
```
Apple clang version 11.0.0 (clang-1100.0.33.8)
```
Update the regex to recognize this as well.