### PR TITLE
Engine switch ignore

### DIFF
--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -367,6 +367,8 @@ namespace metashell
         .flag("-Os", "Optimize for size", ignore)
         .flag("-Ofast", "Disregard strict standards compliance", ignore)
         .flag("-Og", "Optimize debugging experience", ignore)
+        .flag("-m32", "Generate code for 32-bit ABI", ignore)
+        .flag("-m64", "Generate code for 64-bit ABI", ignore)
       ;
       // clang-format on
 

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -412,6 +412,8 @@ namespace metashell
           "Disable the stack protector check",
           ignore
         )
+        .flag("-flto", "Enable link-time optimisation", ignore)
+        .flag("-fno-lto", "Disable link-time optimisation", ignore)
         .flag(
           "-O0",
           "Reduce compilation time and make debugging"

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -349,6 +349,12 @@ namespace metashell
         .flag("-fexceptions", "Enable exception hanlding", ignore)
         .flag("-fno-exceptions", "Disable exception hanlding", ignore)
         .flag(
+          "-fno-rtti",
+          "Disable generation of information about every class"
+          " with virtual functions",
+          ignore
+        )
+        .flag(
           "-O0",
           "Reduce compilation time and make debugging"
           " produce the expected result",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -367,6 +367,12 @@ namespace metashell
           ignore
         )
         .flag(
+          "-fomit-frame-pointer",
+          "Don't keep the frame pointer in a register for"
+          " functions that don't need one.",
+          ignore
+        )
+        .flag(
           "-O0",
           "Reduce compilation time and make debugging"
           " produce the expected result",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -380,6 +380,34 @@ namespace metashell
           ignore
         )
         .flag(
+          "-fstack-protector",
+          "Emit extra code to check for buffer overflows for functions that"
+          " call alloca and functions with buffers larger than 8 bytes.",
+          ignore
+        )
+        .flag(
+          "-fstack-protector-all",
+          "Like -fstack-protector except that all functions are protected.",
+          ignore
+        )
+        .flag(
+          "-fstack-protector-strong",
+          "Like -fstack-protector but includes additional functions to be"
+          " protected.",
+          ignore
+        )
+        .flag(
+          "-fstack-protector-explicit",
+          "Like -fstack-protector but only protects those functions which"
+          " have the stack_protect attribute",
+          ignore
+        )
+        .flag(
+          "-fno-stack-protector",
+          "Disable the stack protector check",
+          ignore
+        )
+        .flag(
           "-O0",
           "Reduce compilation time and make debugging"
           " produce the expected result",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -346,6 +346,8 @@ namespace metashell
           "Place each data item into its own section in the output file",
           ignore
         )
+        .flag("-fexceptions", "Enable exception hanlding", ignore)
+        .flag("-fno-exceptions", "Disable exception hanlding", ignore)
         .flag(
           "-O0",
           "Reduce compilation time and make debugging"

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -305,6 +305,11 @@ namespace metashell
           "Warning-related setting",
           ignore
         )
+        .with_value(
+          "-fvisibility",
+          "Set the default ELF image symbol visibility",
+          ignore
+        )
         .flag(
           "-nostdinc",
           "ignore standard C headers",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -323,6 +323,11 @@ namespace metashell
           ignore
         )
         .flag("-g", dash_g_suffixes(), "Add debug symbols", ignore)
+        .flag(
+          "-pedantic",
+          "Issue all the warnings demanded by strict IDO C and ISO C++",
+          ignore
+        )
       ;
       // clang-format on
 

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -329,6 +329,13 @@ namespace metashell
           ignore
         )
         .flag("-fPIC", "Emit position-independent code", ignore)
+        .flag(
+          "-fvisibility-inlines-hidden",
+          "Declares that the user does not attempt to compare pointers to"
+          " inline functions or methods where the addresses of the two"
+          " functions are taken in different shared object.",
+          ignore
+        )
       ;
       // clang-format on
 

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -328,6 +328,7 @@ namespace metashell
           "Issue all the warnings demanded by strict IDO C and ISO C++",
           ignore
         )
+        .flag("-fPIC", "Emit position-independent code", ignore)
       ;
       // clang-format on
 

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -336,6 +336,16 @@ namespace metashell
           " functions are taken in different shared object.",
           ignore
         )
+        .flag(
+          "-ffunction-sections",
+          "Place each function into its own section in the output file",
+          ignore
+        )
+        .flag(
+          "-fdata-sections",
+          "Place each data item into its own section in the output file",
+          ignore
+        )
       ;
       // clang-format on
 

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -355,6 +355,18 @@ namespace metashell
           ignore
         )
         .flag(
+          "-fno-builtin",
+          "Don't recognize built-in functions that do not begin with"
+          " __builtin_ as prefix",
+          ignore
+        )
+        .flag(
+          "-fno-builtin-function",
+          "Don't recognize built-in functions that do not begin with"
+          " __builtin_ as prefix",
+          ignore
+        )
+        .flag(
           "-O0",
           "Reduce compilation time and make debugging"
           " produce the expected result",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -373,6 +373,13 @@ namespace metashell
           ignore
         )
         .flag(
+          "-funwind-tables",
+          "Similar to -fexceptions, except that it just generates any"
+          " needed static data, but does not affect the generated code in any"
+          " other way.",
+          ignore
+        )
+        .flag(
           "-O0",
           "Reduce compilation time and make debugging"
           " produce the expected result",

--- a/lib/data/src/engine_config.cpp
+++ b/lib/data/src/engine_config.cpp
@@ -346,6 +346,19 @@ namespace metashell
           "Place each data item into its own section in the output file",
           ignore
         )
+        .flag(
+          "-O0",
+          "Reduce compilation time and make debugging"
+          " produce the expected result",
+          ignore
+        )
+        .flag("-O", "Optimize", ignore)
+        .flag("-O1", "Optimize", ignore)
+        .flag("-O2", "Optimize even more", ignore)
+        .flag("-O3", "Optimize yet more", ignore)
+        .flag("-Os", "Optimize for size", ignore)
+        .flag("-Ofast", "Disregard strict standards compliance", ignore)
+        .flag("-Og", "Optimize debugging experience", ignore)
       ;
       // clang-format on
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -75,7 +75,9 @@ TEST(engine_switch, unused_arguments)
                          "-Os",
                          "-Ofast",
                          "-Og",
-                         "-m32"},
+                         "-m32",
+                         "-fno-builtin",
+                         "-fno-builtin-function"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -79,7 +79,11 @@ TEST(engine_switch, unused_arguments)
                          "-fno-builtin",
                          "-fno-builtin-function",
                          "-fomit-frame-pointer",
-                         "-funwind-tables"},
+                         "-funwind-tables",
+                         "-fstack-protector",
+                         "-fstack-protector-all",
+                         "-fstack-protector-strong",
+                         "-fno-stack-protector"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -84,7 +84,9 @@ TEST(engine_switch, unused_arguments)
                          "-fstack-protector-all",
                          "-fstack-protector-strong",
                          "-fno-stack-protector",
-                         "-fvisibility=hidden"},
+                         "-fvisibility=hidden",
+                         "-flto",
+                         "-fno-lto"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -66,6 +66,7 @@ TEST(engine_switch, unused_arguments)
                          "-fdata-sections",
                          "-fexceptions",
                          "-fno-exceptions",
+                         "-fno-rtti",
                          "-O",
                          "-O0",
                          "-O1",

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -57,6 +57,9 @@ TEST(engine_switch, unused_arguments)
                          "-gz=zlib-gnu",
                          "-gused",
                          "-gfull",
+#ifndef _WIN32
+                         "-fPIC",
+#endif
                          "-pedantic"},
                         {},
                         false};

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -83,7 +83,8 @@ TEST(engine_switch, unused_arguments)
                          "-fstack-protector",
                          "-fstack-protector-all",
                          "-fstack-protector-strong",
-                         "-fno-stack-protector"},
+                         "-fno-stack-protector",
+                         "-fvisibility=hidden"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -77,7 +77,8 @@ TEST(engine_switch, unused_arguments)
                          "-Og",
                          "-m32",
                          "-fno-builtin",
-                         "-fno-builtin-function"},
+                         "-fno-builtin-function",
+                         "-fomit-frame-pointer"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -56,7 +56,8 @@ TEST(engine_switch, unused_arguments)
                          "-gz=zlib",
                          "-gz=zlib-gnu",
                          "-gused",
-                         "-gfull"},
+                         "-gfull",
+                         "-pedantic"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -60,7 +60,8 @@ TEST(engine_switch, unused_arguments)
 #ifndef _WIN32
                          "-fPIC",
 #endif
-                         "-pedantic"},
+                         "-pedantic",
+                         "-fvisibility-inlines-hidden"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -63,7 +63,15 @@ TEST(engine_switch, unused_arguments)
                          "-pedantic",
                          "-fvisibility-inlines-hidden",
                          "-ffunction-sections",
-                         "-fdata-sections"},
+                         "-fdata-sections",
+                         "-O",
+                         "-O0",
+                         "-O1",
+                         "-O2",
+                         "-O3",
+                         "-Os",
+                         "-Ofast",
+                         "-Og"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -61,7 +61,9 @@ TEST(engine_switch, unused_arguments)
                          "-fPIC",
 #endif
                          "-pedantic",
-                         "-fvisibility-inlines-hidden"},
+                         "-fvisibility-inlines-hidden",
+                         "-ffunction-sections",
+                         "-fdata-sections"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -74,7 +74,8 @@ TEST(engine_switch, unused_arguments)
                          "-O3",
                          "-Os",
                          "-Ofast",
-                         "-Og"},
+                         "-Og",
+                         "-m32"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -78,7 +78,8 @@ TEST(engine_switch, unused_arguments)
                          "-m32",
                          "-fno-builtin",
                          "-fno-builtin-function",
-                         "-fomit-frame-pointer"},
+                         "-fomit-frame-pointer",
+                         "-funwind-tables"},
                         {},
                         false};
 

--- a/test/system/core/test_engine_switch.cpp
+++ b/test/system/core/test_engine_switch.cpp
@@ -64,6 +64,8 @@ TEST(engine_switch, unused_arguments)
                          "-fvisibility-inlines-hidden",
                          "-ffunction-sections",
                          "-fdata-sections",
+                         "-fexceptions",
+                         "-fno-exceptions",
                          "-O",
                          "-O0",
                          "-O1",


### PR DESCRIPTION
Make Metashell recognise a number of gcc arguments during engine switching.