### PR TITLE
Add -templight-profile support to Clang

### DIFF
--- a/lib/engine/clang/include/metashell/engine/clang/binary.hpp
+++ b/lib/engine/clang/include/metashell/engine/clang/binary.hpp
@@ -22,6 +22,7 @@
 #include <metashell/data/engine_arguments.hpp>
 #include <metashell/data/engine_name.hpp>
 #include <metashell/data/executable_path.hpp>
+#include <metashell/data/metaprogram_mode.hpp>
 #include <metashell/data/result.hpp>
 
 #include <metashell/iface/displayer.hpp>
@@ -105,7 +106,8 @@ namespace metashell
           const iface::environment& env_,
           const boost::optional<data::cpp_code>& tmp_exp_,
           const boost::optional<boost::filesystem::path>& env_path_,
-          binary& clang_binary_);
+          binary& clang_binary_,
+          data::metaprogram_mode mode_);
     }
   }
 }

--- a/lib/engine/clang/src/binary.cpp
+++ b/lib/engine/clang/src/binary.cpp
@@ -428,7 +428,8 @@ namespace metashell
           const iface::environment& env_,
           const boost::optional<data::cpp_code>& tmp_exp_,
           const boost::optional<boost::filesystem::path>& env_path_,
-          binary& binary_)
+          binary& binary_,
+          data::metaprogram_mode mode_)
       {
         data::result precompile_result =
             preprocess(env_, tmp_exp_, env_path_, binary_);
@@ -438,10 +439,14 @@ namespace metashell
           const data::cpp_code precompiled_code(
               std::move(precompile_result.output));
 
-          const data::process_output templight_output = compile(
-              precompiled_code,
-              data::command_line_argument_list{"-Xclang", "-templight-dump"},
-              binary_);
+          data::command_line_argument_list args{"-Xclang", "-templight-dump"};
+          if (mode_ == data::metaprogram_mode::profile)
+          {
+            args += {"-Xclang", "-templight-profile"};
+          }
+
+          const data::process_output templight_output =
+              compile(precompiled_code, args, binary_);
 
           return std::make_tuple(
               exit_success(templight_output) ?

--- a/lib/engine/clang/src/metaprogram_tracer_clang.cpp
+++ b/lib/engine/clang/src/metaprogram_tracer_clang.cpp
@@ -60,7 +60,7 @@ namespace metashell
           iface::displayer& displayer_)
       {
         const auto out = eval_with_templight_dump_on_stdout(
-            env_, expression_, boost::none, _binary);
+            env_, expression_, boost::none, _binary, mode_);
 
         const data::result& res = std::get<0>(out);
         const std::string& trace = std::get<1>(out);

--- a/lib/engine/templight/src/protobuf_trace.cpp
+++ b/lib/engine/templight/src/protobuf_trace.cpp
@@ -121,7 +121,7 @@ namespace metashell
           }
           case ::templight::ProtobufReader::EndEntry:
           {
-            auto end_entry = _reader.LastBeginEntry;
+            auto end_entry = _reader.LastEndEntry;
             _reader.next();
             return data::event_data(
                 data::event_details<data::event_kind::template_end>{

--- a/test/system/mdb/test_metaprograms.hpp
+++ b/test/system/mdb/test_metaprograms.hpp
@@ -129,4 +129,18 @@ const std::string make_unique_sfinae_mp =
   make_unique(Args&&...) = delete;
 )";
 
+const std::string slow_mp =
+    "template<int N>"
+    "static constexpr double heavy(int i, double r) {"
+    "while (i--) r /= 1.1;"
+    "return r;"
+    "}"
+    ""
+    "template<int N>"
+    "struct iter : iter<int(heavy<N>(N * N, N) / N) + N - 1> {};"
+    "template<>"
+    "struct iter<0> { enum { value = 42 }; };"
+    ""
+    "template<int X>"
+    "struct slow_mp { enum { value = iter<X + 123>::value }; };";
 #endif

--- a/test/system/mdb/test_profile.cpp
+++ b/test/system/mdb/test_profile.cpp
@@ -1,0 +1,36 @@
+// Metashell - Interactive C++ template metaprogramming shell
+// Copyright (C) 2020, Abel Sinkovics (abel@sinkovics.hu)
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#include <metashell/system_test/metashell_instance.hpp>
+#include <metashell/system_test/type.hpp>
+
+#include "test_metaprograms.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace metashell::system_test;
+
+TEST(mdb_profile, profile_has_nonzero_time)
+{
+  metashell_instance mi;
+  mi.command(slow_mp);
+  mi.command("#msh mdb -profile slow_mp<0>::value");
+
+  rapidjson::Document d;
+  d.Parse(mi.command("ft").front().get().c_str());
+
+  ASSERT_GT(d["nodes"][0]["time_taken"].GetDouble(), 0);
+}


### PR DESCRIPTION
Hopefully, Clang will soon produce profiling information as part of the
YAML output when ‘-templight-profile’ is present.