### PR TITLE
Remove OS X workaround

### DIFF
--- a/lib/data/src/code_completion.cpp
+++ b/lib/data/src/code_completion.cpp
@@ -20,23 +20,6 @@ namespace metashell
 {
   namespace data
   {
-    namespace
-    {
-      // Workaround until we can upgrade the compiler on OS X.
-      template <class Set>
-      decltype(Set{}.merge(Set{})) merge_maybe_missing_workaround(Set& this_,
-                                                                  Set&& set_)
-      {
-        this_.merge(std::move(set_));
-      }
-
-      template <class Set>
-      void merge_maybe_missing_workaround(Set& this_, const Set& set_)
-      {
-        this_.insert(set_.begin(), set_.end());
-      }
-    }
-
     code_completion::code_completion(std::initializer_list<user_input> vals_)
       : _completions{vals_}
     {
@@ -49,8 +32,7 @@ namespace metashell
 
     void code_completion::insert(code_completion&& comp_)
     {
-      merge_maybe_missing_workaround(
-          _completions, std::move(comp_._completions));
+      _completions.merge(std::move(comp_._completions));
     }
 
     std::optional<user_input> code_completion::pop()


### PR DESCRIPTION
Remove the workaround added due to using an older Clang during the OS X CI builds.