### PR TITLE
Patch compilation errors on macOS

### DIFF
--- a/3rd/readline/src/keymaps.c
+++ b/3rd/readline/src/keymaps.c
@@ -36,7 +36,7 @@
 #include "readline.h"
 #include "rlconf.h"
 
-#include "emacs_keymap.c"
+#include "keymaps.h"
 
 #if defined (VI_MODE)
 #include "vi_keymap.c"

--- a/3rd/readline/src/nls.c
+++ b/3rd/readline/src/nls.c
@@ -53,6 +53,7 @@
 #include "readline.h"
 #include "rlshell.h"
 #include "rlprivate.h"
+#include "xmalloc.h"
 
 static int utf8locale PARAMS((char *));
 


### PR DESCRIPTION
* Declaration of `xfree()` needed to be included in .c file.
* Duplicate symbols for `_emacs_ctlx_keymap _emacs_standard_keymap _emacs_meta_keymap`, because the .c file containing their definion was included in another .c file.