### PR TITLE
Partially revert #266 and solve it the official way

### DIFF
--- a/3rd/readline/CMakeLists.txt
+++ b/3rd/readline/CMakeLists.txt
@@ -17,6 +17,10 @@
 project(readline)
 
 aux_source_directory(src SOURCES)
+
+# These c files are included directly keymaps.c intentionally
+list(REMOVE_ITEM SOURCES src/vi_keymap.c src/emacs_keymap.c)
+
 add_library(${PROJECT_NAME} STATIC ${SOURCES})
 
 disable_warnings(${PROJECT_NAME})

--- a/3rd/readline/src/keymaps.c
+++ b/3rd/readline/src/keymaps.c
@@ -36,7 +36,7 @@
 #include "readline.h"
 #include "rlconf.h"
 
-#include "keymaps.h"
+#include "emacs_keymap.c"
 
 #if defined (VI_MODE)
 #include "vi_keymap.c"


### PR DESCRIPTION
I took a deeper look into how readline's build system works after metashell/metashell#266 , and it seems including c files were intentional. I reverted that change, and instead following the official build system I excluded vi_keymap.c and  emacs_keymap.c from the build. 