### PR TITLE
build: include missing cstddef

### DIFF
--- a/lib/core/include/metashell/core/rapid_ostream_wrapper.hpp
+++ b/lib/core/include/metashell/core/rapid_ostream_wrapper.hpp
@@ -18,6 +18,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <iosfwd>
+#include <cstddef> //for std::size_t
 
 namespace metashell
 {


### PR DESCRIPTION
👋 while regression build 5.0.0 release for macos sequoia, seeing the following build failure:

```
  In file included from /tmp/metashell-20240913-6085-78r7uy/metashell-5.0.0/lib/core/src/rapid_ostream_wrapper.cpp:17:
  /tmp/metashell-20240913-6085-78r7uy/metashell-5.0.0/lib/core/include/metashell/core/rapid_ostream_wrapper.hpp:42:7: error: unknown type name 'size_t'
     42 |       size_t Tell() const;
        |       ^
  /tmp/metashell-20240913-6085-78r7uy/metashell-5.0.0/lib/core/include/metashell/core/rapid_ostream_wrapper.hpp:44:7: error: unknown type name 'size_t'
     44 |       size_t PutEnd(Ch*);
        |       ^
```

thus include `cstddef`

full build log, https://github.com/Homebrew/homebrew-core/actions/runs/10857576037/job/30134228045