### PR TITLE
Fix build with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,12 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.1...3.12)
 
 if(${CMAKE_VERSION} VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-else()
-  cmake_policy(VERSION 3.12)
 endif()
 
 foreach(ENGINE internal templight clang gcc msvc wave)


### PR DESCRIPTION
CMake 4 will error when `cmake_minimum_required` is set to anything less than 3.5. See https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version

According to documentation, the `...<policy-max>` should use the max value (3.12) on CMake 3.12 or newer. For older CMake, it is ignored and the `<min>` value (3.1) is used.